### PR TITLE
bug: Fix multi root problem for mod has replace statement

### DIFF
--- a/internal/edge.go
+++ b/internal/edge.go
@@ -1,0 +1,6 @@
+package internal
+
+type Edge struct {
+	From string
+	To   string
+}

--- a/internal/graph.go
+++ b/internal/graph.go
@@ -1,0 +1,8 @@
+package internal
+
+type Graph struct {
+	Root        string
+	Edges       []Edge
+	MvsPicked   []string
+	MvsUnpicked []string
+}

--- a/main.go
+++ b/main.go
@@ -27,14 +27,21 @@ func main() {
 
 	if err := cmd.Run(); err != nil {
 		color.Red("❌ Error running 'go mod graph': %v", err)
-		panic(err)
+		return
 	}
 
 	color.Green("✅ 'go mod graph' command executed successfully.")
-	result, err := internal.Convert(strings.NewReader(out.String()))
+
+	goModPath := "go.mod"
+	if _, err := os.Stat(goModPath); os.IsNotExist(err) {
+		color.Red("❌ 'go.mod' file not found in the current directory.")
+		return
+	}
+
+	result, err := internal.Convert(strings.NewReader(out.String()), goModPath)
 	if err != nil {
 		color.Red("❌ Error converting graph data: %v", err)
-		panic(err)
+		return
 	}
 
 	color.Green("✅ Graph data converted successfully.")


### PR DESCRIPTION
**Title** : Fix multiple root nodes in dependency graph by ignoring non-root nodes without version

**Description** : This PR addresses the issue of multiple root nodes appearing in the dependency graph when replace directives are used in the go.mod file. 

The changes ensure that: The root node is always set based on the module directive in go.mod, regardless of the presence of replace directives.
During dependency parsing, any node (from or to) that does not contain a version (@) and is not the root module is ignored. This prevents multiple roots from being created.

Using replace directives in go.mod can lead to go mod graph output missing version information for some modules, resulting in multiple root nodes in the generated dependency graph. This change ensures a single root node is maintained, providing a clearer and more accurate visualization of the project's dependencies. It resolves the instability and confusion caused by multiple roots, especially in projects with complex dependency structures (Example: https://github.com/kubernetes/kubernetes). 

related past issues:
https://github.com/golang/go/issues/40513 
https://github.com/golang/go/issues/46365

