### PR TITLE
feature: Add description tooltip for github repository nodes

### DIFF
--- a/internal/template.html
+++ b/internal/template.html
@@ -540,26 +540,35 @@
     const initialY = height / 6;
     svg.call(zoom.transform, d3.zoomIdentity.translate(initialX, initialY).scale(scale));
 
+    const repoCache = new Map();
+
     async function fetchRepoInfo(repo) {
+        if (repoCache.has(repo)) {
+            return repoCache.get(repo);
+        }
+
         const [owner, name] = repo.split('/');
         const url = `https://api.github.com/repos/${owner}/${name}`;
         try {
             const response = await fetch(url);
+            if (response.status === 403) {
+                throw new Error('GitHub API rate limit exceeded or forbidden');
+            }
             if (!response.ok) {
-                throw new Error('GitHub API error');
+                throw new Error(`GitHub API error: ${response.status}`);
             }
             const data = await response.json();
-            return {
+            const repoInfo = {
                 description: data.description || "No description available.",
                 stars: data.stargazers_count,
                 license: data.license ? data.license.spdx_id : "No license information"
             };
+            repoCache.set(repo, repoInfo);
+            return repoInfo;
         } catch (error) {
             console.error("Error fetching repo info:", error);
             return {
-                description: "Failed to fetch information.",
-                stars: null,
-                license: "Unknown"
+                error: error.message
             };
         }
     }
@@ -577,14 +586,14 @@
                 .style("top", (event.pageY - 28) + "px");
 
             const repoInfo = await fetchRepoInfo(repo);
-            if (repoInfo.description) {
-                const starsInfo = repoInfo.stars !== null ? `<br>⭐ ${repoInfo.stars.toLocaleString()} stars` : '';
+            if (repoInfo.error) {
+                tooltip.transition().duration(100).style("opacity", 0);
+            } else if (repoInfo.stars !== undefined) {
+                const starsInfo = `<br>⭐ ${repoInfo.stars.toLocaleString()} stars`;
                 const licenseInfo = `<br>📜 License: ${repoInfo.license}`;
                 tooltip.html(`<strong>${nodeId}</strong><br>${repoInfo.description}${starsInfo}${licenseInfo}`);
             } else {
-                tooltip.transition()
-                    .duration(200)
-                    .style("opacity", 0);
+                tooltip.transition().duration(100).style("opacity", 0);
             }
         }
 
@@ -596,9 +605,7 @@
             d3.select(this).classed("node-hover", true);
         }
     }).on("mouseout", function() {
-        tooltip.transition()
-            .duration(300)
-            .style("opacity", 0);
+        tooltip.transition().duration(200).style("opacity", 0);
 
         clearHighlight();
         clearNodeAndRootHighlight();

--- a/internal/template.html
+++ b/internal/template.html
@@ -54,6 +54,8 @@
             box-shadow: 0 4px 6px rgba(0,0,0,0.1);
             font-size: 14px;
             transition: all 0.2s ease;
+            max-width: 300px;
+            word-wrap: break-word;
         }
         .highlighted {
             stroke: #228be6;
@@ -526,7 +528,44 @@
     const initialY = height / 6;
     svg.call(zoom.transform, d3.zoomIdentity.translate(initialX, initialY).scale(scale));
 
-    node.on("mouseover", function(event, d) {
+    async function fetchRepoDescription(repo) {
+        const [owner, name] = repo.split('/');
+        const url = `https://api.github.com/repos/${owner}/${name}`;
+        try {
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error('GitHub API error');
+            }
+            const data = await response.json();
+            return data.description || null;
+        } catch (error) {
+            console.error("Error fetching repo description:", error);
+            return null;
+        }
+    }
+
+    node.on("mouseover", async function(event, d) {
+        const nodeId = d.data.id;
+        if (nodeId.startsWith("github.com/")) {
+            const repo = nodeId.replace("github.com/", "").split("@")[0];
+            
+            tooltip.transition()
+                .duration(200)
+                .style("opacity", .9);
+            tooltip.html("Loading description...")
+                .style("left", (event.pageX + 10) + "px")
+                .style("top", (event.pageY - 28) + "px");
+
+            const description = await fetchRepoDescription(repo);
+            if (description) {
+                tooltip.html(`<strong>${nodeId}</strong><br>${description}`);
+            } else {
+                tooltip.transition()
+                    .duration(200)
+                    .style("opacity", 0);
+            }
+        }
+
         highlightPathToRoot(d);
         highlightNodeAndRoot(d);
         if (d.data.picked === false) {
@@ -535,6 +574,10 @@
             d3.select(this).classed("node-hover", true);
         }
     }).on("mouseout", function() {
+        tooltip.transition()
+            .duration(300)
+            .style("opacity", 0);
+
         clearHighlight();
         clearNodeAndRootHighlight();
         d3.select(this).classed("node-hover", false);

--- a/internal/template.html
+++ b/internal/template.html
@@ -46,16 +46,25 @@
         }
         .tooltip {
             position: absolute;
-            background-color: rgba(255, 255, 255, 0.95);
-            border: 1px solid #dee2e6;
-            padding: 10px;
-            border-radius: 4px;
+            background-color: rgba(255, 255, 255, 0.98);
+            color: #333;
+            border: none;
+            padding: 12px 16px;
+            border-radius: 8px;
             pointer-events: none;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+            box-shadow: 0 4px 20px rgba(0,0,0,0.15);
             font-size: 14px;
-            transition: all 0.2s ease;
+            line-height: 1.4;
+            transition: all 0.3s ease;
             max-width: 300px;
             word-wrap: break-word;
+            z-index: 1000;
+        }
+        .tooltip strong {
+            display: block;
+            margin-bottom: 6px;
+            font-size: 16px;
+            color: #1a73e8;
         }
         .highlighted {
             stroke: #228be6;
@@ -252,9 +261,12 @@
             fill: #e9ecef;
         }
         body.dark-mode .tooltip {
-            background-color: rgba(40, 40, 40, 0.95);
-            border-color: #4a4a4a;
-            color: #f8f9fa;
+            background-color: rgba(33, 33, 33, 0.98);
+            color: #f0f0f0;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+        }
+        body.dark-mode .tooltip strong {
+            color: #64b5f6;
         }
         body.dark-mode #repo-info,
         body.dark-mode #legend,
@@ -528,7 +540,7 @@
     const initialY = height / 6;
     svg.call(zoom.transform, d3.zoomIdentity.translate(initialX, initialY).scale(scale));
 
-    async function fetchRepoDescription(repo) {
+    async function fetchRepoInfo(repo) {
         const [owner, name] = repo.split('/');
         const url = `https://api.github.com/repos/${owner}/${name}`;
         try {
@@ -537,10 +549,18 @@
                 throw new Error('GitHub API error');
             }
             const data = await response.json();
-            return data.description || null;
+            return {
+                description: data.description || "No description available.",
+                stars: data.stargazers_count,
+                license: data.license ? data.license.spdx_id : "No license information"
+            };
         } catch (error) {
-            console.error("Error fetching repo description:", error);
-            return null;
+            console.error("Error fetching repo info:", error);
+            return {
+                description: "Failed to fetch information.",
+                stars: null,
+                license: "Unknown"
+            };
         }
     }
 
@@ -551,14 +571,16 @@
             
             tooltip.transition()
                 .duration(200)
-                .style("opacity", .9);
-            tooltip.html("Loading description...")
-                .style("left", (event.pageX + 10) + "px")
+                .style("opacity", 1);
+            tooltip.html("<strong>Loading...</strong>")
+                .style("left", (event.pageX + 15) + "px")
                 .style("top", (event.pageY - 28) + "px");
 
-            const description = await fetchRepoDescription(repo);
-            if (description) {
-                tooltip.html(`<strong>${nodeId}</strong><br>${description}`);
+            const repoInfo = await fetchRepoInfo(repo);
+            if (repoInfo.description) {
+                const starsInfo = repoInfo.stars !== null ? `<br>⭐ ${repoInfo.stars.toLocaleString()} stars` : '';
+                const licenseInfo = `<br>📜 License: ${repoInfo.license}`;
+                tooltip.html(`<strong>${nodeId}</strong><br>${repoInfo.description}${starsInfo}${licenseInfo}`);
             } else {
                 tooltip.transition()
                     .duration(200)

--- a/internal/template.html
+++ b/internal/template.html
@@ -541,6 +541,16 @@
     svg.call(zoom.transform, d3.zoomIdentity.translate(initialX, initialY).scale(scale));
 
     const repoCache = new Map();
+    let debounceTimer;
+
+    function debounce(func, delay) {
+        return function() {
+            const context = this;
+            const args = arguments;
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(() => func.apply(context, args), delay);
+        };
+    }
 
     async function fetchRepoInfo(repo) {
         if (repoCache.has(repo)) {
@@ -573,28 +583,36 @@
         }
     }
 
-    node.on("mouseover", async function(event, d) {
+    const debouncedFetchRepoInfo = debounce(async (repo, event, d) => {
+        const repoInfo = await fetchRepoInfo(repo);
+        updateTooltip(repoInfo, event, d);
+    }, 300);
+
+    function updateTooltip(repoInfo, event, d) {
+        if (repoInfo.error) {
+            tooltip.transition().duration(100).style("opacity", 0);
+        } else if (repoInfo.stars !== undefined) {
+            const starsInfo = `<br>⭐ ${repoInfo.stars.toLocaleString()} stars`;
+            const licenseInfo = `<br>📜 License: ${repoInfo.license}`;
+            tooltip.html(`<strong>${d.data.id}</strong><br>${repoInfo.description}${starsInfo}${licenseInfo}`)
+                .style("left", (event.pageX + 15) + "px")
+                .style("top", (event.pageY - 28) + "px");
+            tooltip.transition().duration(200).style("opacity", 1);
+        } else {
+            tooltip.transition().duration(100).style("opacity", 0);
+        }
+    }
+
+    node.on("mouseover", function(event, d) {
         const nodeId = d.data.id;
         if (nodeId.startsWith("github.com/")) {
             const repo = nodeId.replace("github.com/", "").split("@")[0];
             
-            tooltip.transition()
-                .duration(200)
-                .style("opacity", 1);
+            tooltip.transition().duration(200).style("opacity", 1);
             tooltip.html("<strong>Loading...</strong>")
                 .style("left", (event.pageX + 15) + "px")
                 .style("top", (event.pageY - 28) + "px");
-
-            const repoInfo = await fetchRepoInfo(repo);
-            if (repoInfo.error) {
-                tooltip.transition().duration(100).style("opacity", 0);
-            } else if (repoInfo.stars !== undefined) {
-                const starsInfo = `<br>⭐ ${repoInfo.stars.toLocaleString()} stars`;
-                const licenseInfo = `<br>📜 License: ${repoInfo.license}`;
-                tooltip.html(`<strong>${nodeId}</strong><br>${repoInfo.description}${starsInfo}${licenseInfo}`);
-            } else {
-                tooltip.transition().duration(100).style("opacity", 0);
-            }
+            debouncedFetchRepoInfo(repo, event, d);
         }
 
         highlightPathToRoot(d);
@@ -607,6 +625,7 @@
     }).on("mouseout", function() {
         tooltip.transition().duration(200).style("opacity", 0);
 
+        clearTimeout(debounceTimer);
         clearHighlight();
         clearNodeAndRootHighlight();
         d3.select(this).classed("node-hover", false);


### PR DESCRIPTION
# Add GitHub Repository Information Tooltip

## Description
This PR introduces a new feature that displays GitHub repository information in a tooltip when hovering over dependency nodes. The tooltip shows the repository description, star count, and license information.

## Changes
- Implement `fetchRepoInfo` function to retrieve repository data from GitHub API
- Add tooltip functionality to node hover events
- Implement caching mechanism to reduce API calls and improve performance
- Handle API rate limiting and error cases gracefully

## Benefits
- Provides users with quick access to important repository information
- Enhances the overall user experience by offering more context about dependencies

## Notes
- This feature requires an active internet connection to fetch repository data
- Consider future enhancements such as configurable API tokens for increased rate limits

![tooltip](https://github.com/user-attachments/assets/e4ed3ae3-be62-433b-9472-b5896ed02941)
