### PR TITLE
bug: Fix search result cycling when using different search term

### DIFF
--- a/internal/template.html
+++ b/internal/template.html
@@ -717,8 +717,11 @@
 
     let searchResults = [];
     let currentSearchIndex = 0;
+    let lastSearchTerm = '';
 
     function searchNodes(searchTerm) {
+        lastSearchTerm = searchTerm;
+
         searchResults = treeData.descendants().filter(node => node.data.id.toLowerCase().includes(searchTerm));
         currentSearchIndex = 0;
         if (searchResults.length > 0) {
@@ -769,7 +772,9 @@
 
     d3.select("#search-input").on("keypress", (event) => {
         if (event.key === "Enter") {
-            if (searchResults.length > 0) {
+            const searchTerm = d3.select("#search-input").property("value").toLowerCase();
+
+            if (searchResults.length > 0 && searchTerm === lastSearchTerm) {
                 currentSearchIndex = (currentSearchIndex + 1) % searchResults.length;
                 focusOnSearchResult();
             } else {


### PR DESCRIPTION
Hi there! thanks for making this great tool!

## Bug

I found a subtle bug in the search functionality. Basically when I hit the "Enter" key with the search term "first_dep" and then change my search term to "second_dep", hitting the "Enter" key again would still cycle me through the results of "first_dep"

NOTE: this doesn't happen if i were to manually click the search icon

## Fix

The fix i made was pretty straightforward -- i added a `lastSearch` term to track changes in the search input
The code now correctly handles transitions between different search terms when hitting "Enter" key
